### PR TITLE
handle requests for invalid hierarchies

### DIFF
--- a/teachrecovery/main/tests/test_views.py
+++ b/teachrecovery/main/tests/test_views.py
@@ -2,6 +2,7 @@ from django.test import TestCase
 from django.test.client import Client
 from pagetree.helpers import get_hierarchy
 from django.contrib.auth.models import User
+from django.http import Http404
 from teachrecovery.main.views import (
     DynamicHierarchyMixin, RestrictedModuleMixin,
     TeachRecoveryPageView,
@@ -83,6 +84,10 @@ class PagetreeViewTestsLoggedIn(TestCase):
         r = self.c.get("/")
         self.assertEqual(r.status_code, 200)
 
+    def test_invalid_hierarchy(self):
+        r = self.c.get("/pages/invalid/test/")
+        self.assertEqual(r.status_code, 404)
+
 
 class DynamicHierarchyMixinTest(TestCase):
     def test_dispatch(self):
@@ -131,6 +136,11 @@ class RestrictedModuleMixinTest(TestCase):
         UserModule.objects.create(user=self.u, hierarchy=self.root.hierarchy,
                                   is_allowed=True)
         self.assertTrue(m.dispatch())
+
+    def test_invalid_hierarchy(self):
+        m = M(self.u, "invalid")
+        with self.assertRaises(Http404):
+            m.dispatch()
 
 
 class TeachRecoveryPageViewTest(TestCase):

--- a/teachrecovery/main/views.py
+++ b/teachrecovery/main/views.py
@@ -9,7 +9,7 @@ from pagetree.generic.views import generic_instructor_page
 from pagetree.models import UserPageVisit, Hierarchy
 from teachrecovery.main.models import UserModule, ResourcePage
 from django.http.response import HttpResponseNotFound
-from django.shortcuts import render
+from django.shortcuts import render, get_object_or_404
 
 
 class LoggedInMixinSuperuser(object):
@@ -53,13 +53,14 @@ class DynamicHierarchyMixin(object):
             return HttpResponseNotFound(msg)
         else:
             self.hierarchy_name = name
-            self.hierarchy_base = Hierarchy.objects.get(name=name).base_url
+            self.hierarchy_base = get_object_or_404(
+                Hierarchy, name=name).base_url
         return super(DynamicHierarchyMixin, self).dispatch(*args, **kwargs)
 
 
 class RestrictedModuleMixin(object):
     def dispatch(self, *args, **kwargs):
-        hierarchy = Hierarchy.objects.get(name=self.hierarchy_name)
+        hierarchy = get_object_or_404(Hierarchy, name=self.hierarchy_name)
         um = UserModule.objects.filter(user=self.request.user,
                                        hierarchy=hierarchy,
                                        is_allowed=True)


### PR DESCRIPTION
respond with 404's, not 500's.

https://sentry.ccnmtl.columbia.edu/sentry-internal/teachrecovery/group/823/