### PR TITLE
Cas

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ factory_boy==2.4.1
 python-ldap==2.4.19
 sqlparse==0.1.14
 
-djangowind==0.13.3
+djangowind==0.14.0
 sorl==3.1
 django-appconf==1.0.1
 django-compressor==1.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ factory_boy==2.4.1
 python-ldap==2.4.19
 sqlparse==0.1.14
 
-djangowind==0.14.0
+djangowind==0.14.1
 sorl==3.1
 django-appconf==1.0.1
 django-compressor==1.5

--- a/teachrecovery/main/tests/test_views.py
+++ b/teachrecovery/main/tests/test_views.py
@@ -17,7 +17,7 @@ class BasicTest(TestCase):
     def test_root(self):
         response = self.c.get("/")
         self.assertEquals(response.status_code, 200)
-        self.assertContains(response, 'Columbia Log In')
+        self.assertContains(response, 'CAS Login')
 
     def test_smoketest(self):
         response = self.c.get("/smoketest/")

--- a/teachrecovery/settings_shared.py
+++ b/teachrecovery/settings_shared.py
@@ -171,10 +171,11 @@ COMPRESS_ROOT = "media/"
 AUTHENTICATION_BACKENDS = ('djangowind.auth.CAS2AuthBackend',
                            'django.contrib.auth.backends.ModelBackend', )
 CAS_BASE = "https://teachrecovery.cumc.columbia.edu/"
-WIND_PROFILE_HANDLERS = ['djangowind.auth.CDAPProfileHandler']
-WIND_AFFIL_HANDLERS = ['djangowind.auth.AffilGroupMapper',
-                       'djangowind.auth.StaffMapper',
-                       'djangowind.auth.SuperuserMapper']
+CAS_TICKETID_FIELD_NAME = 'ticket'
+CAS_DEFAULT_NEXT = '/'
+
+WIND_PROFILE_HANDLERS = []
+WIND_AFFIL_HANDLERS = ['djangowind.auth.AffilGroupMapper']
 WIND_STAFF_MAPPER_GROUPS = ['tlc.cunix.local:columbia.edu']
 WIND_SUPERUSER_MAPPER_GROUPS = [
     'anp8', 'jb2410', 'zm4', 'cld2156',

--- a/teachrecovery/settings_shared.py
+++ b/teachrecovery/settings_shared.py
@@ -168,9 +168,9 @@ COMPRESS_ROOT = "media/"
 
 # WIND settings
 
-AUTHENTICATION_BACKENDS = ('djangowind.auth.SAMLAuthBackend',
+AUTHENTICATION_BACKENDS = ('djangowind.auth.CAS2AuthBackend',
                            'django.contrib.auth.backends.ModelBackend', )
-CAS_BASE = "https://cas.columbia.edu/"
+CAS_BASE = "https://teachrecovery.cumc.columbia.edu/"
 WIND_PROFILE_HANDLERS = ['djangowind.auth.CDAPProfileHandler']
 WIND_AFFIL_HANDLERS = ['djangowind.auth.AffilGroupMapper',
                        'djangowind.auth.StaffMapper',

--- a/teachrecovery/templates/base.html
+++ b/teachrecovery/templates/base.html
@@ -170,7 +170,6 @@ Raven.setUserContext({
                       {% if CAS_BASE %}
                           <form method="get" action="{{ CAS_BASE }}cas/login">
                             {% csrf_token %}
-                              <input type="hidden" name="gateway" value="true" />
                               <input type="hidden" name="service" value="http{% if request.is_secure %}s{% endif %}://{{ request.get_host }}/accounts/caslogin/?next=/" />
                               <p>[Need different verbiage here]</p>
                               <input class="regbutton" type="submit"

--- a/teachrecovery/templates/base.html
+++ b/teachrecovery/templates/base.html
@@ -170,15 +170,13 @@ Raven.setUserContext({
                       {% if CAS_BASE %}
                           <form method="get" action="{{ CAS_BASE }}cas/login">
                             {% csrf_token %}
-                              <input type="hidden" name="gateway" value="1" />
+                              <input type="hidden" name="gateway" value="true" />
                               <input type="hidden" name="service" value="http{% if request.is_secure %}s{% endif %}://{{ request.get_host }}/accounts/caslogin/?next=/" />
-                              <p>If you have a Columbia University Network ID (UNI)...</p>
-                              <input class="regbutton" type="submit" value="Columbia Log In" />
+                              <p>[Need different verbiage here]</p>
+                              <input class="regbutton" type="submit"
+                              value="CAS Login" />
                           </form>
                       {% endif %}
-
-                      <p class="smalltxt"><a href="http://cuit.columbia.edu/cuit/manage-my-uni" title="Learn more about UNI" target="_blank">What is a UNI?</a></p>
-                      <!-- End UNI LOG IN -->
 
                       <hr class="seperator" />
 

--- a/teachrecovery/templates/base.html
+++ b/teachrecovery/templates/base.html
@@ -169,8 +169,9 @@ Raven.setUserContext({
                   <div class="content">
                       {% if CAS_BASE %}
                           <form method="get" action="{{ CAS_BASE }}cas/login">
-                              {% csrf_token %}
-                              <input type="hidden" name="destination" value="http{% if request.is_secure %}s{% endif %}://{{ request.get_host }}/accounts/caslogin/?next={{ next }}" />
+                            {% csrf_token %}
+                              <input type="hidden" name="gateway" value="1" />
+                              <input type="hidden" name="service" value="http{% if request.is_secure %}s{% endif %}://{{ request.get_host }}/accounts/caslogin/?next=/" />
                               <p>If you have a Columbia University Network ID (UNI)...</p>
                               <input class="regbutton" type="submit" value="Columbia Log In" />
                           </form>


### PR DESCRIPTION
it's a bit weird though. AFAICT, the Drupal end is not doing a redirect
that it's supposed to do.

* you click the CAS LOGIN button on the Django app
* it takes you to:

    https://teachrecovery.cumc.columbia.edu/cas/login?service=https://teachrecovery.ccnmtl.columbia.edu/accounts/caslogin/?next=/

* which immediately redirects you to:

    https://teachrecovery.cumc.columbia.edu/user?destination=cas/login

* when you enter a valid username/password there, it just deposits you
  at:

    https://teachrecovery.cumc.columbia.edu/

* if you go back to the django app and hit the CAS LOGIN button now, it
  properly redirects back to our cas endpoint with a valid ticketid and
  Django can log you in.

So, the issue is that somewhere on the Drupal side, instead of
redirecting to the specified 'service' URL with a ticketid immediately
after logging in, it instead just redirects to what I assume is some
kind of Drupal default login.

I dug up the PHP code for the Drupal CAS provider and the relevent bit
looks like:

```
function cas_server_login() {
  // Set login cookie so that we know we're in the process of logging in
  global $user;
  $output='';
  $service = isset($_REQUEST['service']) ? $_REQUEST['service'] : '';
  $gateway = isset($_REQUEST['gateway']);
  if ($user->uid) {
    if ($service) {
      $_COOKIE[CAS_LOGIN_COOKIE] = $service;
    }
    $output=t('You have successfully logged into CAS');
    cas_server_service_return();
  }
  else {
    if ($gateway && $service) {
      drupal_goto($service);
    }
    else {
      // Redirect to user login
      if ($service) {
        setcookie(CAS_LOGIN_COOKIE, $service);
      }
      $output .= l(t('Login'), 'user', array('query' => array('destination' => 'cas/login')));
      drupal_goto('user', array('query' => array('destination' => 'cas/login')));
    }
  }
  return $output;
}
```

which basically looks OK.

If you're not already logged in, it stashes the service URL into a
cookie (which I've verified) and then redirects to the local Drupal
login with 'cas/login' as the destination. The next time the browser
ends up back there, it pulls the service URL back out of the cookie and
redirects to it with a ticket.

It just appears that something else somewhere else in the Drupal setup
is interfering and sends it back to the site index instead of the
specified destination after login.

Anyway, at this point, I'm fairly certain that things are correct
on *our* end, so this should go out so we can start pressing to get the
Drupal end fixed up.